### PR TITLE
pc - add AUTO_SERVER=TRUE to h2 urls

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -1,6 +1,6 @@
 logging.level.sql=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-spring.datasource.url=jdbc:h2:file:./target/db-development
+spring.datasource.url=jdbc:h2:file:./target/db-development;AUTO_SERVER=TRUE
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true

--- a/src/main/resources/application-wiremock.properties
+++ b/src/main/resources/application-wiremock.properties
@@ -1,6 +1,6 @@
 logging.level.sql=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
-spring.datasource.url=jdbc:h2:file:./target/db-development
+spring.datasource.url=jdbc:h2:file:./target/db-development;AUTO_SERVER=TRUE
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true


### PR DESCRIPTION
Closes #1 

This PR adds `AUTO_SERVER=TRUE` to h2 urls.

This helps support concurrent access to the H2 database.

See: <https://h2database.com/html/features.html?highlight=AUTO_SERVER&search=AUTO_SERVER#auto_mixed_mode>