### PR TITLE
pc - add database table for urls

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/Url.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/Url.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents a url. */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "urls")
+public class Url {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String url;
+  private String shortDescription;
+  private String longDescription;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UrlRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UrlRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.Url;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * The UrlRepository is a repository for Url entities, that is, it is the abstraction for the
+ * database table for Urls
+ */
+@Repository
+public interface UrlRepository extends CrudRepository<Url, Long> {}

--- a/src/main/resources/db/migration/changes/Urls.json
+++ b/src/main/resources/db/migration/changes/Urls.json
@@ -1,0 +1,64 @@
+{ "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "Urls",
+        "author": "pconrad",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "URLS"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
+                {
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "URLS_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+
+                {
+                  "column": {  
+                    "constraints": {
+                      "nullable": false
+                    },
+                    "name": "URL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "SHORT_DESCRIPTION",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "LONG_DESCRIPTION",
+                    "type": "VARCHAR(255)"
+                  }
+                }
+              ],
+              "tableName": "URLS"
+            }
+          }]
+  
+      }
+    }
+  ]}


### PR DESCRIPTION
In this PR, we add a database table for Urls.   

This PR contains the entity class, the repository class, and the database migration file only.

There are no user facing changes.