### PR TITLE
Silence Toastify During Integration Tests

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -14,7 +14,7 @@ root.render(
     <BrowserRouter>
       {/* Wrap your app with BrowserRouter */}
       <QueryClientProvider client={queryClient}>
-        <ToastContainer />
+        {import.meta.env.VITE_SILENCE_TOASTIFY !== "true" && <ToastContainer />}
         <App />
       </QueryClientProvider>
     </BrowserRouter>

--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,9 @@
                 </goals>
                 <configuration>
                   <arguments>run build</arguments>
+                  <environmentVariables>
+                    <VITE_SILENCE_TOASTIFY>true</VITE_SILENCE_TOASTIFY>
+                  </environmentVariables>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
In this PR, I add a vite environmental variable to `main.jsx` that allows us to prevent Toastify alerts from spawning during integration tests. The variable is packaged in during the build process, and is readable when being rendered during integration tests.

This allows us to make our tests more deterministic, as Playwright will not error upon matching to a Toastify alert as well as the actual table.

## Testing Plan
run the following command:
```bash
HEADLESS=false INTEGRATION=true mvn clean test-compile failsafe:integration-test -Dit.test=RestaurantWebIT
```

Note that during the testing process, Toastify alerts should not spawn after creating a Restaurant.

Deployed to https://team02-dev-Division7.dokku-00.cs.ucsb.edu/
