### PR TITLE
Updated frontend connection instructions to use --lts instead of 20.17.0

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/FrontendProxyController.java
@@ -48,7 +48,7 @@ public class FrontendProxyController {
             """
                 <p>Failed to connect to the frontend server...</p>
                 <p>On Dokku, be sure that <code>PRODUCTION</code> is defined.</p>
-                <p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>nvm use 20.17.0; npm ci; npm start</code></p>
+                <p>On localhost, open a second terminal window, cd into <code>frontend</code> and type: <code>nvm use --lts; npm ci; npm start</code></p>
                 <p>Or, you may click to access: </p>
                 <ul>
                   <li><a href='/swagger-ui/index.html'>/swagger-ui/index.html</a></li>


### PR DESCRIPTION
Closes #113

In this PR I simply update the fallback instructions on localhost that appear when the backend is running but not the frontend. I change the instruction from 'nvm use 20.17.0' to 'nvm use --lts'